### PR TITLE
Issue-17: Add GHA to copy docs to /docs/fdo

### DIFF
--- a/.github/workflows/copy-docs.yml
+++ b/.github/workflows/copy-docs.yml
@@ -1,0 +1,24 @@
+name : Copy Docs
+on: 
+  push:
+    branches:
+      - main
+    paths:
+      - 'docs/**'
+ 
+jobs:
+  copy:
+    runs-on: ubuntu-latest
+    steps:
+    - name: Copycat
+      uses: andstor/copycat-action@v3
+      with:
+        commit_message: "Syncing from FDO-support"
+        clean: false
+        personal_token: ${{ secrets.PERSONAL_TOKEN }}
+        src_path: docs
+        dst_path: /docs/fdo
+        dst_owner: open-horizon
+        dst_repo_name: open-horizon.github.io
+        dst_branch: master
+        src_branch: main


### PR DESCRIPTION
@johnwalicki It looks like the secrets are defined at the ORG level, so we shouldn't have to configure anything there for this GHA.  I'm not sure how to test this other than to merge and run.  I changed the GHA for the destination path, and the src branch from "master" to "main" since that's what this repo uses.  There shouldn't need to be any other changes.