### PR TITLE
Issue #21 - Documentation: FDO reference docs

### DIFF
--- a/docs/FDO-APIs.md
+++ b/docs/FDO-APIs.md
@@ -1,5 +1,20 @@
-# FDO Owner Services API
+---
+copyright:
+years: 2022 - 2023
+lastupdated: "2023-02-19"
+title: "FDO API guide"
+description: "FDO API detailed documentation"
 
+parent: FDO Protocol Reference
+nav_order: 1
+grand_parent: Administering
+---
+
+# FDO API documentation
+
+This page describes the FIDO Device Onboard (FDO) REST API interfaces.
+
+## FDO Owner Services API
 
 ***NOTE***: These REST APIs use Digest authentication. `api_user` and `api_password` properties specify the credentials to be used while making the REST calls. The value for `api_user` is present in `service.yml` file and value for `api_password` is present in `service.env` file.
 
@@ -11,16 +26,16 @@
 | GET /api/v1/owner/vouchers | Returns a list of all Ownership Voucher GUIDs. | | | | line separated list of GUIDs | curl  -D - --digest -u ${api_user}: --location --request GET "http://localhost:8042/api/v1/owner/vouchers" --header 'Content-Type: text/plain' |
 | GET /api/v1/owner/vouchers/<device_guid> | Returns the Ownership Voucher for the specified GUID. | Path - id: Device GUID | | | Ownership Voucher | curl  -D - --digest -u ${api_user}: --location --request GET "http://localhost:8042/api/v1/owner/vouchers/${device_guid}" --header 'Content-Type: text/plain' |
 | POST /api/v1/owner/vouchers/ | Insert Ownership Voucher against the specified GUID in `ONBOARDING_VOUCHER` table. | | text/plain | Content of Ownership Voucher in PEM Format | Guid of the device |  curl  -D - --digest -u ${api_user}: --location --request POST "http://localhost:8042/api/v1/owner/vouchers" --header 'Content-Type: text/plain' --data-raw '${voucher}' |
-| GET /api/v1/logs | Serves the log from the owner service | | | | owner logs| curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/api/v1/logs' | 
+| GET /api/v1/logs | Serves the log from the owner service | | | | owner logs| curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/api/v1/logs' |
 | DELETE /api/v1/logs | Deletes the log from the owner service | | |  | | curl  -D - --digest -u ${api_user}:  --location --request DELETE 'http://localhost:8042/api/v1/logs' |
 | GET /health | Returns the health status |  |  | | Current version |  curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/health'|
-| GET /api/v1/ondie | Serves the stored certs & crls files | | | | Ondie certs & crl files | curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/api/v1/ondie' | 
+| GET /api/v1/ondie | Serves the stored certs & crls files | | | | Ondie certs & crl files | curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/api/v1/ondie' |
 | POST /api/v1/ondie | To insert onDie certs and crls zip file to DB | | text/plain | Path to ondie cert file | |  curl -D - --digest -u ${api_user}:${api_passwd} --location --request POST "http://${ip}:{port}/api/v1/ondie" --header 'Content-Type: text/plain' --data-raw "${cert-file}" |
 | GET /api/v1/certificate?filename=fileName | Returns the certificate file based on filename | Query - filename | | | Certificate file in PKCS12 format | curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8042/api/v1/certificate?filename=ssl.p12' |
 | GET /api/v1/certificate?alias={alias} | Returns the owner certificate of the given alias type | Query - alias | | | Certificate PEM format | curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8042/api/v1/certificate?alias=SECP256R1' --header 'Content-Type: text/plain' |
 | GET /api/v1/certificate?uuid=uuid | Returns the owner alias type for the given voucher| Query - uuid | | |  UUID's attestation type | curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8042/api/v1/certificate?uuid=cc60f0aa-56d0-492e-8c8d-9a1fe55cb60 --header 'Content-Type: text/plain' |
 | POST /api/v1/certificate?filename=fileName | Adds the certificate file to DB based on filename | Query - filename | text/plain | PKCS12 Certificate file in Binary format |  | curl -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8042/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' --data-binary '@< path to ssl.p12 >' |
-| DELETE /api/v1/certificate?filename=fileName | Delete the certificate file to DB based on filename | Query - filename | | |  | curl  -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8042/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' | 
+| DELETE /api/v1/certificate?filename=fileName | Delete the certificate file to DB based on filename | Query - filename | | |  | curl  -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8042/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' |
 | POST /api/v1/certificate/validity?days=no_of_days | Updates certificate validity in `CERTIFICATE_VALIDITY` table | | text/plain |  | | curl  -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8042/api/v1/certificate/validity?days=10'  --header 'Content-Type: text/plain' |
 | GET /api/v1/certificate/validity | Collects certificate validity days from  `CERTIFICATE_VALIDITY` table | |  | | Number of Days| curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8042/api/v1/certificate/validity' |
 | GET /api/v1/owner/messagesize | Collects the max message size from `ONBOARDING_CONFIG` table | | |  | MAX_MESSAGE_SIZE | curl -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8042/api/v1/owner/messagesize' --header 'Content-Type: text/plain'|
@@ -33,7 +48,6 @@
 | POST /api/v1/resell/{guid} | Gets extended resell Ownership Voucher with the guid. | Path - guid of the device to resell | | Owner Certificate | The Ownership voucher in PEM format |   curl -D - --digest -u ${api_user}: --location --request POST "http://localhost:8039/api/v1/resell/${guid}" --header 'Content-Type: text/plain' --data-raw  "$owner_certificate" -o ${serial_no}_voucher.txt |
 | GET /api/v1/owner/state/{guid} | Returns the TO status the associated GUID | GUID of the device |  |  | Returns TO2 completed status & TO0 expiry (timestamps) |  curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/api/v1/owner/state/{guid}' |
 
-
 Following is the list of REST response error codes and it's possible causes :
 
 |     Error Code     |             Possible Causes               |
@@ -44,9 +58,7 @@ Following is the list of REST response error codes and it's possible causes :
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, Owner unable to fetch/copy/delete the requested file. |
 
-#
-
-# FDO PRI Rendezvous REST APIs
+## FDO PRI Rendezvous REST APIs
 
 ***NOTE***: These REST APIs use Digest authentication. `api_user` and `api_password` properties specify the credentials to be used while making the REST calls.
 
@@ -55,8 +67,8 @@ Following is the list of REST response error codes and it's possible causes :
 | ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|-----------------:|
 | GET /api/v1/certificate?filename=fileName | Returns the certificate file based on filename | Query - filename | | | Certificate file in PKCS12 format | curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8040/api/v1/certificate?filename=ssl.p12' |
 | POST /api/v1/certificate?filename=fileName | Adds the certificate file to DB based on filename | Query - filename | text/plain| PKCS12 Certificate file in Binary format |  | curl -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8040/api/v1/certificate?filename=ssl.p12' --data-binary '@< path to ssl.p12 >' |
-| DELETE /api/v1/certificate?filename=fileName | Delete the certificate file to DB based on filename | Query - filename | | |  | curl  -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8040/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' | 
-| GET /api/v1/logs | Serves the log from the RV service | | | | RV logs| curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8040/api/v1/logs' | 
+| DELETE /api/v1/certificate?filename=fileName | Delete the certificate file to DB based on filename | Query - filename | | |  | curl  -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8040/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' |
+| GET /api/v1/logs | Serves the log from the RV service | | | | RV logs| curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8040/api/v1/logs' |
 | DELETE /api/v1/logs | Deletes the log from the RV service | | |  | | curl  -D - --digest -u ${api_user}:  --location --request DELETE 'http://localhost:8040/api/v1/logs' |
 | POST /api/v1/certificate/validity?days=no_of_days | Updates certificate validity in `CERTIFICATE_VALIDITY` table | | text/plain|  | | curl  -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8040/api/v1/certificate/validity?days=10' |
 | GET /api/v1/certificate/validity | Collects certificate validity days from  `CERTIFICATE_VALIDITY` table | |  | | Number of Days| curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8040/api/v1/certificate/validity' |
@@ -64,7 +76,6 @@ Following is the list of REST response error codes and it's possible causes :
 | POST /api/v1/rv/allow | Adds public key to allowed list of Owners in RV |  |  text/plain |  certificate in pem format | |   curl  -D - --digest -u ${api_user}:  --location --request POST 'http://localhost:8040/api/v1/rv/allow` --data-raw  "$owner_certificate" |
 | DELETE /api/v1/rv/allow | delete public key to allowed list of Owners in RV |  |  text/plain |  certificate in pem format | |   curl  -D - --digest -u ${api_user}:  --location --request POST 'http://localhost:8040/api/v1/rv/allow` --data-raw  "$owner_certificate" |
 | POST /api/v1/rv/deny | Adds public key to denied list of Owners in RV |  |  text/plain |  certificate in pem format | |   curl  -D - --digest -u ${api_user}:  --location --request POST 'http://localhost:8040/api/v1/rv/deny` --data-raw  "$owner_certificate" |
-
 
 Following is the list of REST response error codes and it's description :
 
@@ -76,9 +87,7 @@ Following is the list of REST response error codes and it's description :
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, RV unable to fetch/copy/delete the requested file. |
 
-#
-
-# FDO PRI Manufacturer REST APIs
+## FDO PRI Manufacturer REST APIs
 
 ***NOTE***: These REST APIs use Digest authentication. `api_user` and `api_password` properties specify the credentials to be used while making the REST calls. The value for `api_user` is present in `service.yml` file and value for `api_password` is present in `service.env` file.
 
@@ -87,10 +96,10 @@ Following is the list of REST response error codes and it's description :
 | POST /api/v1/mfg/vouchers/<serial_no> | Gets extended Ownership Voucher with the serial number. | Path - Device Serial Number | | Owner Certificate | Extended Voucher |   curl -D - --digest -u ${api_user}: --location --request POST "http://localhost:8039/api/v1/mfg/vouchers/${serial_no}" --header 'Content-Type: text/plain' --data-raw  "$owner_certificate" -o ${serial_no}_voucher.txt |
 | GET /api/v1/certificate?filename=fileName | Returns the certificate file based on filename | Query - filename | |  | Keystore file in binary format | curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8039/api/v1/certificate?filename=ssl.p12' |
 | POST /api/v1/certificate?filename=fileName | Adds the certificate file to DB based on filename | Query - filename | text/plain| PKCS12 Certificate file in Binary format |  | curl -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8039/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' --data-binary '@< path to ssl.p12 >' |
-| DELETE /api/v1/certificate?filename=fileName | Delete the certificate file to DB based on filename | Query - filename | | |  | curl  -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8039/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' | 
+| DELETE /api/v1/certificate?filename=fileName | Delete the certificate file to DB based on filename | Query - filename | | |  | curl  -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8039/api/v1/certificate?filename=ssl.p12' --header 'Content-Type: text/plain' |
 | POST /api/v1/rvinfo/ | Updates RV Info in `RV_DATA` table | | text/plain | RV Info |   |  curl  -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8039/api/v1/rvinfo' --header 'Content-Type: text/plain' --data-raw '[[[5,"localhost"],[3,8040],[12,1],[2,"127.0.0.1"],[4,8041]]]' |
-| GET /api/v1/deviceinfo/{seconds} | Serves the serial no. and GUID of the devices that completed DI in the last `n` seconds | Path - `n` seconds |  |  | JSON array of Serial No, GUID ,DI Timestamp and Attestion type. | curl -D - --digest -u apiUser:  --location --request GET 'http://localhost:8080/api/v1/deviceinfo/30' --header 'Content-Type: text/plain' | 
-| GET /api/v1/logs | Serves the log from the manufacturer service | | | | Manufacturer logs| curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8039/api/v1/logs' --header 'Content-Type: text/plain'| 
+| GET /api/v1/deviceinfo/{seconds} | Serves the serial no. and GUID of the devices that completed DI in the last `n` seconds | Path - `n` seconds |  |  | JSON array of Serial No, GUID ,DI Timestamp and Attestion type. | curl -D - --digest -u apiUser:  --location --request GET 'http://localhost:8080/api/v1/deviceinfo/30' --header 'Content-Type: text/plain' |
+| GET /api/v1/logs | Serves the log from the manufacturer service | | | | Manufacturer logs| curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8039/api/v1/logs' --header 'Content-Type: text/plain'|
 | DELETE /api/v1/logs | Deletes the log from the manufacturer service | | |  | | curl  -D - --digest -u ${api_user}:  --location --request DELETE 'http://localhost:8039/api/v1/logs' --header 'Content-Type: text/plain'|
 | POST /api/v1/certificate/validity?days=no_of_days | Updates certificate validity in `CERTIFICATE_VALIDITY` table | Query - days | text/plain |  | | curl  -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8039/api/v1/certificate/validity?days=10' --header 'Content-Type: text/plain' |
 | GET /api/v1/certificate/validity | Collects certificate validity days from  `CERTIFICATE_VALIDITY` table | |  | | Number of Days| curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8039/api/v1/certificate/validity' |
@@ -106,9 +115,7 @@ Following is the list of REST response error codes and it's possible causes :
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, MFG unable to fetch/copy/delete the requested file. |
 
-#
-
-# FDO PRI Reseller REST APIs
+## FDO PRI Reseller REST APIs
 
 | Operation                      | Description                        | Path/Query Parameters    | Content Type   |Request Body  | Response Body | Sample cURL call |
 | ------------------------------:|:----------------------------------:|:------------------------:|:--------------:|-------------:|--------------:|-----------------:|
@@ -117,7 +124,6 @@ Following is the list of REST response error codes and it's possible causes :
 | GET /api/v1/owner/vouchers/<device_guid> | Returns the Ownership Voucher for the specified GUID. | Query - id: Device GUID | | | Ownership Voucher | curl  -D - --digest -u ${api_user}: --location --request GET "http://localhost:8070/api/v1/owner/vouchers/${device_guid}" --header 'Content-Type: text/plain' |
 | POST /api/v1/owner/vouchers/ | Insert Ownership Voucher against the specified GUID in `ONBOARDING_VOUCHER` table. | | text/plain | Content of Ownership Voucher in PEM Format | |  curl  -D - --digest -u ${api_user}: --location --request POST "http://localhost:8070/api/v1/owner/vouchers" --header 'Content-Type: text/plain' --data-binary '${voucher}' |
 
- 
 Following is the list of REST response error codes and it's possible causes :
 
 |     Error Code     |             Possible Causes               |

--- a/docs/FDO-APIs.md
+++ b/docs/FDO-APIs.md
@@ -47,6 +47,7 @@ This page describes the FIDO Device Onboard (FDO) REST API interfaces.
 | DELETE /api/v1/owner/resource?filename=fileName | Delete the  file from DB based on filename from `SYSTEM_RESOURCE` table   | Query - filename | | |  |  curl -D - --digest -u ${api_user}: --location --request DELETE 'http://localhost:8042/api/v1/owner/resource?filename=fileName' --header 'Content-Type: text/plain'|
 | POST /api/v1/resell/{guid} | Gets extended resell Ownership Voucher with the guid. | Path - guid of the device to resell | | Owner Certificate | The Ownership voucher in PEM format |   curl -D - --digest -u ${api_user}: --location --request POST "http://localhost:8039/api/v1/resell/${guid}" --header 'Content-Type: text/plain' --data-raw  "$owner_certificate" -o ${serial_no}_voucher.txt |
 | GET /api/v1/owner/state/{guid} | Returns the TO status the associated GUID | GUID of the device |  |  | Returns TO2 completed status & TO0 expiry (timestamps) |  curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8042/api/v1/owner/state/{guid}' |
+{: caption="Table 1. FDO Owner Services API" caption-side="top"}
 
 Following is the list of REST response error codes and it's possible causes :
 
@@ -57,6 +58,7 @@ Following is the list of REST response error codes and it's possible causes :
 | `405 Method Not Allowed` | When an unsupported REST method is requested. Currently, Owner supports GET, POST and DELETE only. |
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, Owner unable to fetch/copy/delete the requested file. |
+{: caption="Table 2. FDO Owner Services API response error codes" caption-side="top"}
 
 ## FDO PRI Rendezvous REST APIs
 
@@ -76,6 +78,7 @@ Following is the list of REST response error codes and it's possible causes :
 | POST /api/v1/rv/allow | Adds public key to allowed list of Owners in RV |  |  text/plain |  certificate in pem format | |   curl  -D - --digest -u ${api_user}:  --location --request POST 'http://localhost:8040/api/v1/rv/allow` --data-raw  "$owner_certificate" |
 | DELETE /api/v1/rv/allow | delete public key to allowed list of Owners in RV |  |  text/plain |  certificate in pem format | |   curl  -D - --digest -u ${api_user}:  --location --request POST 'http://localhost:8040/api/v1/rv/allow` --data-raw  "$owner_certificate" |
 | POST /api/v1/rv/deny | Adds public key to denied list of Owners in RV |  |  text/plain |  certificate in pem format | |   curl  -D - --digest -u ${api_user}:  --location --request POST 'http://localhost:8040/api/v1/rv/deny` --data-raw  "$owner_certificate" |
+{: caption="Table 3. FDO PRI Rendezvous API" caption-side="top"}
 
 Following is the list of REST response error codes and it's description :
 
@@ -86,6 +89,7 @@ Following is the list of REST response error codes and it's description :
 | `405 Method Not Allowed` | When an unsupported REST method is requested. Currently, RV supports GET, PUT and DELETE only. |
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, RV unable to fetch/copy/delete the requested file. |
+{: caption="Table 4. FDO PRI Rendezvous API response error codes" caption-side="top"}
 
 ## FDO PRI Manufacturer REST APIs
 
@@ -104,6 +108,7 @@ Following is the list of REST response error codes and it's description :
 | POST /api/v1/certificate/validity?days=no_of_days | Updates certificate validity in `CERTIFICATE_VALIDITY` table | Query - days | text/plain |  | | curl  -D - --digest -u ${api_user}: --location --request POST 'http://localhost:8039/api/v1/certificate/validity?days=10' --header 'Content-Type: text/plain' |
 | GET /api/v1/certificate/validity | Collects certificate validity days from  `CERTIFICATE_VALIDITY` table | |  | | Number of Days| curl  -D - --digest -u ${api_user}: --location --request GET 'http://localhost:8039/api/v1/certificate/validity' |
 | GET /health | Returns the health status |  |  | | Current version |  curl  -D - --digest -u ${api_user}:  --location --request GET 'http://localhost:8039/health' |
+{: caption="Table 5. FDO PRI Manufacturer API" caption-side="top"}
 
 Following is the list of REST response error codes and it's possible causes :
 
@@ -114,6 +119,7 @@ Following is the list of REST response error codes and it's possible causes :
 | `405 Method Not Allowed` | When an unsupported REST method is requested. Currently, MFG supports GET, POST and DELETE only. |
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, MFG unable to fetch/copy/delete the requested file. |
+{: caption="Table 6. FDO PRI Rendezvous API" caption-side="top"}
 
 ## FDO PRI Reseller REST APIs
 
@@ -123,6 +129,7 @@ Following is the list of REST response error codes and it's possible causes :
 | GET /api/v1/owner/vouchers | Returns a list of all Ownership Voucher GUIDs. | | | | line separated list of GUIDs | curl  -D - --digest -u ${api_user}: --location --request GET "http://localhost:8070/api/v1/owner/vouchers" --header 'Content-Type: text/plain' |
 | GET /api/v1/owner/vouchers/<device_guid> | Returns the Ownership Voucher for the specified GUID. | Query - id: Device GUID | | | Ownership Voucher | curl  -D - --digest -u ${api_user}: --location --request GET "http://localhost:8070/api/v1/owner/vouchers/${device_guid}" --header 'Content-Type: text/plain' |
 | POST /api/v1/owner/vouchers/ | Insert Ownership Voucher against the specified GUID in `ONBOARDING_VOUCHER` table. | | text/plain | Content of Ownership Voucher in PEM Format | |  curl  -D - --digest -u ${api_user}: --location --request POST "http://localhost:8070/api/v1/owner/vouchers" --header 'Content-Type: text/plain' --data-binary '${voucher}' |
+{: caption="Table 7. FDO PRI Reseller API" caption-side="top"}
 
 Following is the list of REST response error codes and it's possible causes :
 
@@ -133,3 +140,4 @@ Following is the list of REST response error codes and it's possible causes :
 | `405 Method Not Allowed` | When an unsupported REST method is requested. Currently, Reseller supports GET, POST and DELETE only. |
 | `406 Not Acceptable` | When an invalid filename is passed through the REST endpoints. |
 | `500 Internal Server Error` | Due to internal error, Reseller unable to fetch/copy/delete the requested file. |
+{: caption="Table 8. FDO PRI Reseller API response error codes" caption-side="top"}

--- a/docs/README-FDO1.1.md
+++ b/docs/README-FDO1.1.md
@@ -28,13 +28,9 @@ For the instructions in this document, `<fdo-pri-src>` refers to the path of the
 FDO PRI source code is organized into the following sub-folders.
 
 - `component-samples`: It contains all the normative and non-normative server and client implementation with all specifications listed in the base profile.
-
 - `http-api-samples`: It contains Servlet implementation for various operations to be performed using different REST endpoints for all server service.
-
 - `protocol-samples`: It contains client and server implementation that demonstrates the preliminary E2E demo that educates the end user with the protocol workflow.
-
 - `protocol`: It contains implementations related to protocol message processing.
-
 - `util`: It contains utility package such as storage, ServiceInfo, dispatchers - for message passing and cert-utils - for loading certificates and keys from PEM formatted strings.
 
 ## Building FDO PRI Source
@@ -52,6 +48,7 @@ Use the following commands to build FDO PRI source.
 cd <fdo-pri-src>
 mvn clean install
 ```
+{: codeblock}
 
 The build creates artifacts which will be used in the rest of this guide.
 
@@ -65,6 +62,7 @@ The build creates artifacts which will be used in the rest of this guide.
 cd <fdo-pri-src>/protocol-samples/http-server-to0-to1-sample/
 mvn exec:java
 ```
+{: codeblock}
 
 The server will listen for FDO PRI http messages on port 8040.
 The H2 database will listen on TCP port 8050.
@@ -75,6 +73,7 @@ The H2 database will listen on TCP port 8050.
 cd <fdo-pri-src>/protocol-samples/http-server-to2-sample/
 mvn exec:java
 ```
+{: codeblock}
 
 The server will listen for FDO PRI HTTP messages on port 8042.
 The H2 database will listen on TCP port 8051.
@@ -85,10 +84,11 @@ The H2 database will listen on TCP port 8051.
 cd <fdo-pri-src>/protocol-samples/http-server-di-sample/
 mvn exec:java
 ```
+{: codeblock}
 
 The server will listen for FDO PRI HTTP messages on port 8039.
 The H2 database will listen on TCP port 8049.
-You can allow remote database console connections by setting webAllowOthers=true in the .h2.server.properties file located your user home directory (for example, '~' for Linux and C:\Users\[username] for Windows).
+You can allow remote database console connections by setting webAllowOthers=true in the .h2.server.properties file located your user home directory (for example, '~' for Linux and C:\Users\\\[username] for Windows).
 
 ### Running FDO PRI HTTP Clients
 
@@ -98,6 +98,7 @@ You can allow remote database console connections by setting webAllowOthers=true
 cd <fdo-pri-src>/protocol-samples/http-client-di-sample
 mvn exec:java
 ```
+{: codeblock}
 
 Expect the following line on successful DI completion.
 
@@ -115,6 +116,7 @@ Refer [Ownership Voucher Creation](#ownership-voucher-creation) for next steps.
 cd <fdo-pri-src>/protocol-samples/http-client-to0-sample
 mvn exec:java
 ```
+{: codeblock}
 
 Expect the following message on successful TO0 completion.
 
@@ -128,6 +130,7 @@ TO0 Client finished.
 cd <fdo-pri-src>/protocol-samples/http-client-to1-sample
 mvn exec:java
 ```
+{: codeblock}
 
 signed RV Blob: 84a10126...
 TO1 Client finished.
@@ -138,6 +141,7 @@ TO1 Client finished.
 cd <fdo-pri-src>/protocol-samples/http-client-to2-sample
 mvn exec:java
 ```
+{: codeblock}
 
 TO2 Client finished.
 
@@ -150,6 +154,7 @@ WARNING: Please consider reporting this to the maintainers of com.google.inject.
 WARNING: Use --illegal-access=warn to enable warnings of further illegal reflective access operations
 WARNING: All illegal access operations will be denied in a future release
 ```
+{: codeblock}
 
 ## Ownership Voucher Creation
 
@@ -172,6 +177,7 @@ To log in to the database and view records use the following information:
 "Password:" = "" (blank)
 "JDBC URL:" = "jdbc:h2:tcp://<localhost>:8049/<fdo-pri-src>/protocol-samples/http-server-di-sample/target/data/mfg"
 ```
+{: codeblock}
 
 The path to the DB will be printed out in the following format when the DI server is starting.
 
@@ -195,6 +201,7 @@ To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` pro
 db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <service_db_port>
 webAllowOthers = true
 ```
+{: codeblock}
 
 **IMPORTANT: Not recommended to enable this setting especially on production systems.**
 
@@ -211,7 +218,6 @@ To enable Rendezvous Bypass
 
 - Update the RVInfo blob with `rvbypass` flag and owner address using the API `POST /api/v1/rvinfo` with
   `http://<owner-ip:port>?rvbypass=&ipaddress=<owner-ip>&ownerport=<port>` as body.
-
 - Setting the `rvbypass` flag in RVblob, causes the TO1 protocol to be skipped, and a TO2 connection
  to be attempted to `<owner-ip>` address mentioned in the above POST body.
 
@@ -229,6 +235,4 @@ Refer to [Demo README](component-samples/demo/README.md) for steps to run compon
 
 Refer to [Demo README](component-samples/demo/README.md) for steps to configure component-samples to support OnDie devices.
 
-Support for OnDie devices is built into the protocol-samples and no configuration is required. The OnDie certs and CRLs are preloaded into the
-protocol-samples/onDieCache directory. Should these need to be refreshed (in case of devices released after the FDO PRI release) then the script in
-component-samples/onDieScript.py can be used to update the artifacts in this directory.
+Support for OnDie devices is built into the protocol-samples and no configuration is required. The OnDie certs and CRLs are preloaded into the protocol-samples/onDieCache directory. Should these need to be refreshed (in case of devices released after the FDO PRI release) then the script in component-samples/onDieScript.py can be used to update the artifacts in this directory.

--- a/docs/README-FDO1.1.md
+++ b/docs/README-FDO1.1.md
@@ -1,13 +1,25 @@
-***NOTE***: This is a preliminary implementation of the [FIDO Device Onboard Spec](https://fidoalliance.org/specs/FDO/fido-device-onboard-v1.0-ps-20210323/) published by the FIDO Alliance. The implementation is experimental and incomplete, and is not ready for use in any production capacity. Some cryptographic algorithms and encoding formats have not been implemented, and any aspect of this implementation is subject to change.
+---
+copyright:
+years: 2022 - 2023
+lastupdated: "2023-02-19"
+title: "FDO Protocol Reference"
+description: "FDO Protocol Reference Implementation Quick Start"
+
+parent: Administering
+nav_order: 3
+has_children: true
+---
 
 # FIDO Device Onboard (FDO) Protocol Reference Implementation (PRI) Quick Start
 
-## System Requirements:
+***NOTE***: This is a preliminary implementation of the [FIDO Device Onboard Spec](https://fidoalliance.org/specs/FDO/fido-device-onboard-v1.0-ps-20210323/) published by the FIDO Alliance. The implementation is experimental and incomplete, and is not ready for use in any production capacity. Some cryptographic algorithms and encoding formats have not been implemented, and any aspect of this implementation is subject to change.
 
-* **Ubuntu 20.04**.
-* **Maven 3.6.3**.
-* **Java 11**.
-* **Haveged**.
+## System Requirements
+
+- **Ubuntu 20.04**
+- **Maven 3.6.3**
+- **Java 11**
+- **Haveged**
 
 ## Source Layout
 
@@ -35,9 +47,10 @@ Ensure that these ports are not used by other applications while building and ex
 binaries.
 
 Use the following commands to build FDO PRI source.
-```
-$ cd <fdo-pri-src>
-$ mvn clean install
+
+```bash
+cd <fdo-pri-src>
+mvn clean install
 ```
 
 The build creates artifacts which will be used in the rest of this guide.
@@ -47,27 +60,30 @@ The build creates artifacts which will be used in the rest of this guide.
 ### Starting FDO PRI HTTP Servers
 
 #### Starting the FDO PRI Rendezvous (RV) HTTP Server
-```
-$ cd <fdo-pri-src>/protocol-samples/http-server-to0-to1-sample/
-$ mvn exec:java
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-server-to0-to1-sample/
+mvn exec:java
 ```
 
 The server will listen for FDO PRI http messages on port 8040.
 The H2 database will listen on TCP port 8050.
 
 #### Starting the FDO PRI Owner HTTP Server
-```
-$ cd <fdo-pri-src>/protocol-samples/http-server-to2-sample/
-$ mvn exec:java
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-server-to2-sample/
+mvn exec:java
 ```
 
 The server will listen for FDO PRI HTTP messages on port 8042.
 The H2 database will listen on TCP port 8051.
 
 #### Starting the FDO PRI Device Initialization (DI) HTTP Server
-```
-$ cd <fdo-pri-src>/protocol-samples/http-server-di-sample/
-$ mvn exec:java
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-server-di-sample/
+mvn exec:java
 ```
 
 The server will listen for FDO PRI HTTP messages on port 8039.
@@ -77,10 +93,12 @@ You can allow remote database console connections by setting webAllowOthers=true
 ### Running FDO PRI HTTP Clients
 
 #### Running the FDO PRI Device Initialization (DI) HTTP Client
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-client-di-sample
+mvn exec:java
 ```
-$ cd <fdo-pri-src>/protocol-samples/http-client-di-sample
-$ mvn exec:java
-```
+
 Expect the following line on successful DI completion.
 
 SerialNo: d35a096f
@@ -92,10 +110,12 @@ DI Client finished.
 Refer [Ownership Voucher Creation](#ownership-voucher-creation) for next steps.
 
 #### Running the FDO PRI TO0 HTTP Client
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-client-to0-sample
+mvn exec:java
 ```
-$ cd <fdo-pri-src>/protocol-samples/http-client-to0-sample
-$ mvn exec:java
-```
+
 Expect the following message on successful TO0 completion.
 
 TO0 Response Wait: 3600
@@ -103,24 +123,27 @@ TO0 Response Wait: 3600
 TO0 Client finished.
 
 #### Running the FDO PRI TO1 HTTP Client
-```
-$ cd <fdo-pri-src>/protocol-samples/http-client-to1-sample
-$ mvn exec:java
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-client-to1-sample
+mvn exec:java
 ```
 
 signed RV Blob: 84a10126...
 TO1 Client finished.
 
 ### Running the FDO PRI TO2 HTTP Client
-```
-$ cd <fdo-pri-src>/protocol-samples/http-client-to2-sample
-$ mvn exec:java
+
+```bash
+cd <fdo-pri-src>/protocol-samples/http-client-to2-sample
+mvn exec:java
 ```
 
 TO2 Client finished.
 
 ***NOTE***: During the execution of the Protocol Samples using the command 'mvn exec:java', the following warning messages may be displayed on the console. These warning messages are a result of the version discrepancy of Guice with Maven and Java 11. This does not have any effect on the execution of the Protocol Sample.
-```
+
+```text
 WARNING: An illegal reflective access operation has occurred
 WARNING: Illegal reflective access by com.google.inject.internal.cglib.core.$ReflectUtils$1 (file:/usr/share/maven/lib/guice.jar) to method java.lang.ClassLoader.defineClass(java.lang.String,byte[],int,int,java.security.ProtectionDomain)
 WARNING: Please consider reporting this to the maintainers of com.google.inject.internal.cglib.core.$ReflectUtils$1
@@ -143,38 +166,39 @@ http://localhost:8039/api/v1/vouchers/<serial_no>
 The hex value of the extended Ownership Voucher can be obtained by running the API above. The value will be populated on DI server console.
 
 To log in to the database and view records use the following information:
-```
+
+```text
 "User Name:" = "sa"
 "Password:" = "" (blank)
 "JDBC URL:" = "jdbc:h2:tcp://<localhost>:8049/<fdo-pri-src>/protocol-samples/http-server-di-sample/target/data/mfg"
 ```
+
 The path to the DB will be printed out in the following format when the DI server is starting.
 
 `jdbc:h2:tcp:...`
 
 SELECT * FROM MT_DEVICES will show the current Ownership Vouchers created by DI messages.
 
-# Enabling Remote Access to DB
+## Enabling Remote Access to DB
 
 Remote access to H2 Sample Storage DB has been disabled by default. Enabling the access creates a security hole in the system which makes it vulnerable to Remote Code Execution.
 
 To enable remote access to DB update the `db.tcpServer` and `webAllowOthers` properties in the following files:
 
+- To enable remote access for DI server DB, update file:  `<fdo-pri-src>/protocol-samples/http-server-di-sample/src/main/java/org/fidoalliance/fdo/sample/DiApp.java`
 
-- To enable remote access for DI server DB, update file:  `<fdo-pri-src>/protocol-samples/http-server-di-sample/src/main/java/org/fidoalliance/fdo/sample/DiApp.java` <br/>
-
-- To enable remote access for TO0-TO1 server DB, update file:  `<fdo-pri-src>/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ServerApp.java` <br/>
+- To enable remote access for TO0-TO1 server DB, update file:  `<fdo-pri-src>/protocol-samples/http-server-to0-to1-sample/src/main/java/org/fidoalliance/fdo/sample/To0To1ServerApp.java`
 
 - To enable remote access for TO2 server DB, update file: `<fdo-pri-src>/protocol-samples/http-server-to2-sample/src/main/java/org/fidoalliance/fdo/sample/To2ServerApp.java`
 
-```
+```text
 db.tcpServer = -tcp -tcpAllowOthers -ifNotExists -tcpPort <service_db_port>
 webAllowOthers = true
 ```
 
 **IMPORTANT: Not recommended to enable this setting especially on production systems.**
 
-# Enabling Rendezvous Bypass
+## Enabling Rendezvous Bypass
 
 FDO includes a Rendezvous Bypass mechanism that is useful for IOT deployments that are not
 dependent on a particular network structure or ownership.
@@ -191,17 +215,17 @@ To enable Rendezvous Bypass
 - Setting the `rvbypass` flag in RVblob, causes the TO1 protocol to be skipped, and a TO2 connection
  to be attempted to `<owner-ip>` address mentioned in the above POST body.
 
-# EPID Test Mode
+## EPID Test Mode
 
 EPID devices can be tested using `Test` mode. EPID `Test` mode feature is intended to support onboarding for `development` and `test` devices. Enabling the test mode means signature verification won't be performed for the device. Test mode is enabled by default for protocol-sample in components.
 
 ***NOTE***: Not recommended for use in production systems.
 
-# Using Component Samples
+## Using Component Samples
 
 Refer to [Demo README](component-samples/demo/README.md) for steps to run component sample demo.
 
-# Support for OnDie Devices
+## Support for OnDie Devices
 
 Refer to [Demo README](component-samples/demo/README.md) for steps to configure component-samples to support OnDie devices.
 


### PR DESCRIPTION
Fixes: #21 

- Lint the API and Protocol reference pages
- Add the front matter and navigation tags
- Adjust `#` headers

This PR will force the CopyDocs GHA to run and copy the docs over to a section under the 
https://open-horizon.github.io/docs/administering_index/
page.