### PR TITLE
Issue 25: Updated FDO To Use Intel's Version 1.1.5

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,17 +2,9 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.2.0] - 2023-05-24
+## [1.1.0] - 2023-05-24
 - Issue 25: Updated FDO to support Intel's `1.1.5` release.
 - Updated FDO fetch address to reference FDO's new development organization domain.
 - Updated Docker container's base image to Red Hat UBI 9 minimal.
 
-## [1.1.0] - 2022-03-25
-
-## [1.0.2] - 2022-01-25
-
-## [1.0.1] - 2021-12-17
-
-## [1.0.0] - 2021-12-17
-
-## [0.5.0] - 2021-04-30
+## [1.0.0]

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,9 +2,17 @@
 
 All notable changes to this project will be documented in this file.
 
-## [1.1.0] - 2023-05-24
+## [1.2.0] - 2023-05-24
 - Issue 25: Updated FDO to support Intel's `1.1.5` release.
 - Updated FDO fetch address to reference FDO's new development organization domain.
 - Updated Docker container's base image to Red Hat UBI 9 minimal.
 
-## [1.0.0]
+## [1.1.0] - 2022-03-25
+
+## [1.0.2] - 2022-01-25
+
+## [1.0.1] - 2021-12-17
+
+## [1.0.0] - 2021-12-17
+
+## [0.5.0] - 2021-04-30

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,10 @@
+# Changelog
+
+All notable changes to this project will be documented in this file.
+
+## [1.1.0] - 2023-05-24
+- Issue 25: Updated FDO to support Intel's `1.1.5` release.
+- Updated FDO fetch address to reference FDO's new development organization domain.
+- Updated Docker container's base image to Red Hat UBI 9 minimal.
+
+## [1.0.0]

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and FDO-owner-services (for now they use the samme version number)
-export VERSION ?= 1.1.0
+export VERSION ?= 1.2.0
 # used by sample-mfg/Makefile. Needs to match what is in fdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
 FDO_VERSION ?= 1.1.5
-STABLE_VERSION ?= 1.1.0
+STABLE_VERSION ?= 1.2.0
 
 #todo: add BUILD_NUMBER like in anax/Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and FDO-owner-services (for now they use the samme version number)
-export VERSION ?= 1.2.0
+export VERSION ?= 1.1.0
 # used by sample-mfg/Makefile. Needs to match what is in fdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
 FDO_VERSION ?= 1.1.5
-STABLE_VERSION ?= 1.2.0
+STABLE_VERSION ?= 1.1.0
 
 #todo: add BUILD_NUMBER like in anax/Makefile
 

--- a/Makefile
+++ b/Makefile
@@ -2,7 +2,7 @@ SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and FDO-owner-services (for now they use the samme version number)
 export VERSION ?= 1.0.0
 # used by sample-mfg/Makefile. Needs to match what is in fdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
-FDO_VERSION ?= 1.1.4
+FDO_VERSION ?= 1.1.5
 STABLE_VERSION ?= 1.0.0
 
 #todo: add BUILD_NUMBER like in anax/Makefile

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and FDO-owner-services (for now they use the samme version number)
-export VERSION ?= 1.0.0
+export VERSION ?= 1.1.0
 # used by sample-mfg/Makefile. Needs to match what is in fdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
 FDO_VERSION ?= 1.1.5
-STABLE_VERSION ?= 1.0.0
+STABLE_VERSION ?= 1.1.0
 
 #todo: add BUILD_NUMBER like in anax/Makefile
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Horizon FDO 1.0
+# Open Horizon FDO 1.1.0
 
 ## Overview of the Open Horizon FDO Support
 
@@ -71,7 +71,7 @@ The FDO owner services are packaged as a single docker container that can be run
 7. Start the FDO owner services docker container and view the log:
 
    ```bash
-   ./run-fdo-owner-service.sh 1.0.0
+   ./run-fdo-owner-service.sh 1.1.0
    docker logs -f fdo-owner-services
    ```
 
@@ -79,12 +79,22 @@ The FDO owner services are packaged as a single docker container that can be run
 
 Before continuing with the rest of the FDO process, it is good to verify that you have the correct information necessary to reach the FDO owner service endpoints. **On a Horizon "admin" host** run these simple FDO APIs to verify that the services are accessible and responding properly. (A Horizon admin host is one that has the `horizon-cli` package installed, which provides the `hzn` command, and has the environment variables `HZN_EXCHANGE_URL`, `HZN_FDO_SVC_URL`, and `HZN_EXCHANGE_USER_AUTH` set correctly for your Horizon management hub.)
 
+Intel FIDO Deivce Onboard RV Servers:
+```bash
+ Development:
+   http://test.fdorv.com:80
+   
+ Production:
+   http://fdorv.com:80
+```
+
+
 1. Export these environment variables for the subsequent steps. Contact the management hub installer for the exact values:
 
    ```bash
    export HZN_EXCHANGE_USER_AUTH=iamapikey:<password>
    export HZN_FDO_SVC_URL=<protocol>://<fdo-owner-svc-host>:9008
-   export FDO_RV_URL=http://sdo.lfedge.iol.unh.edu:80
+   export FDO_RV_URL=http://test.fdorv.com:80
    ```
 
 2. Query the Owner services and Ocs API  health and version:

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ DROP DATABASE fdo;
 
 #### <a name="troubleshooting"></a>Troubleshooting
 
-- If the edge device does not give a `[INFO ] TO2 completed successfully. [INFO ] Starting Fdo Completed`, check /fdo/pri-fidoiot-v1.1.4/owner/app-data/service.log or use command `docker logs -f fdo-owner-services` for error messages.
+- If the edge device does not give a `[INFO ] TO2 completed successfully. [INFO ] Starting Fdo Completed`, check /fdo/pri-fidoiot-v1.1.5/owner/app-data/service.log or use command `docker logs -f fdo-owner-services` for error messages.
 - If your Owner, RV or Manufacturer service does not respond, you can check the logs in the same location as above. If the logs never printed that it started the service, for example: "Started Owner Service", then make sure you have all dependencies installed and environment variables correctly exported.
 - If your Service Info Package fails during the process of getting onboarded to the edge device, make sure you posted the file correctly to the owner service DB. Also make sure that you posted the correct To2 address.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Horizon FDO 1.1.0
+# Open Horizon FDO 1.2.0
 
 ## Overview of the Open Horizon FDO Support
 
@@ -71,7 +71,7 @@ The FDO owner services are packaged as a single docker container that can be run
 7. Start the FDO owner services docker container and view the log:
 
    ```bash
-   ./run-fdo-owner-service.sh 1.1.0
+   ./run-fdo-owner-service.sh 1.2.0
    docker logs -f fdo-owner-services
    ```
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-# Open Horizon FDO 1.2.0
+# Open Horizon FDO 1.1.0
 
 ## Overview of the Open Horizon FDO Support
 
@@ -71,7 +71,7 @@ The FDO owner services are packaged as a single docker container that can be run
 7. Start the FDO owner services docker container and view the log:
 
    ```bash
-   ./run-fdo-owner-service.sh 1.2.0
+   ./run-fdo-owner-service.sh 1.1.0
    docker logs -f fdo-owner-services
    ```
 

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,4 @@
-FROM registry.access.redhat.com/ubi8/ubi-minimal:8.0
+FROM registry.access.redhat.com/ubi9-minimal:latest
 
 # Builds a composite docker service that the "owner" needs to run. Specifically it contains the following services:
 #   Intel FDO development/test rendezvous service
@@ -42,11 +42,16 @@ WORKDIR /root
 # To search for rpms (or for what rpms provides a command): http://www.rpm-find.net/linux/RPM/
 # Note: libssl-dev is is required by all the fdo services on ubuntu. I think the equivalent rpm is openssl-devel
 # Note: due to a bug in microdnf, using the --nodocs option causes an exit code of 141: https://github.com/rpm-software-management/microdnf/issues/50
-RUN curl -sS -o epel-release-latest-8.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
-    rpm -i /root/epel-release-latest-8.noarch.rpm && \
-    microdnf update -y && \
-    microdnf install --nodocs -y openssl ca-certificates tar findutils shadow-utils procps openssl-devel haveged && \
+RUN mkdir -p /run/user/$UID && \
+    microdnf update -y --nodocs 1>/dev/null 2>&1 && \
+    microdnf install -y --nodocs ca-certificates findutils gettext java-11-openjdk openssl procps shadow-utils tar 1>/dev/null 2>&1 && \
     microdnf clean all
+
+#RUN curl -sS -o epel-release-latest-8.noarch.rpm https://dl.fedoraproject.org/pub/epel/epel-release-latest-8.noarch.rpm && \
+#    rpm -i /root/epel-release-latest-8.noarch.rpm && \
+#    microdnf update -y && \
+#    microdnf install --nodocs -y openssl ca-certificates tar findutils shadow-utils procps openssl-devel haveged && \
+#    microdnf clean all
 
 RUN useradd -r -u 1000 -g root fdouser \
     && mkdir /home/fdouser \
@@ -57,13 +62,13 @@ RUN useradd -r -u 1000 -g root fdouser \
 #RUN curl -sS -o openjre-11_linux-x64_bin.tar.gz https://cdn.azul.com/zulu/bin/zulu11.33.15-ca-jre11.0.4-linux_x64.tar.gz && \
 #RUN curl -sS -o openjre-11_linux-x64_bin.tar.gz https://cdn.azul.com/zulu/bin/zulu11.43.55-ca-jre11.0.9.1-linux_x64.tar.gz && \
 #    mv zulu11.*-linux_x64 /usr/lib/jvm/openjre-11-manual-installation && \
-RUN curl -sSL -o openjre-11_linux-x64_bin.tar.gz https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jre_x64_linux_11.0.15_10.tar.gz && \
-    sha256sum openjre-11_linux-x64_bin.tar.gz && \
-    tar xzf openjre-11_linux-x64_bin.tar.gz && \
-    rm openjre-11_linux-x64_bin.tar.gz && \
-    mkdir -p /usr/lib/jvm && \
-    mv openjdk-11.0.15_10-jre /usr/lib/jvm/openjre-11-manual-installation && \
-    update-alternatives --install /usr/bin/java java /usr/lib/jvm/openjre-11-manual-installation/bin/java 1
+#RUN curl -sSL -o openjre-11_linux-x64_bin.tar.gz https://github.com/AdoptOpenJDK/openjdk11-upstream-binaries/releases/download/jdk-11.0.15%2B10/OpenJDK11U-jre_x64_linux_11.0.15_10.tar.gz && \
+#    sha256sum openjre-11_linux-x64_bin.tar.gz && \
+#    tar xzf openjre-11_linux-x64_bin.tar.gz && \
+#    rm openjre-11_linux-x64_bin.tar.gz && \
+#    mkdir -p /usr/lib/jvm && \
+#    mv openjdk-11.0.15_10-jre /usr/lib/jvm/openjre-11-manual-installation && \
+#    update-alternatives --install /usr/bin/java java /usr/lib/jvm/openjre-11-manual-installation/bin/java 1
 
 # this doesn't work here, because docker writes /etc/hosts when it starts the container
 #RUN echo "127.0.0.1 RVFDO OwnerFDO" >> /etc/hosts
@@ -73,19 +78,19 @@ WORKDIR $WORKDIR
 
 # Get the license file
 COPY LICENSE.txt /licenses/
-COPY fdo/NOTICES-v1.1.4/pri-fidoiot/* /licenses/FDOIotPlatformSDK/
+COPY fdo/NOTICES-v1.1.5/pri-fidoiot/* /licenses/FDOIotPlatformSDK/
 
 # Get owner db files. The owner subdir will be created automatically by COPY
 # Note: need to use uid and gid to be able to build on non-linux hosts
-COPY --chown=1000:0 fdo/pri-fidoiot-v1.1.4/db $WORKDIR/pri-fidoiot-v1.1.4/db/
+COPY --chown=1000:0 fdo/pri-fidoiot-v1.1.5/db $WORKDIR/pri-fidoiot-v1.1.5/db/
 
 # Get owner service files. The owner subdir will be created automatically by COPY
 # Note: need to use uid and gid to be able to build on non-linux hosts
-COPY --chown=1000:0 fdo/pri-fidoiot-v1.1.4/owner $WORKDIR/pri-fidoiot-v1.1.4/owner/
+COPY --chown=1000:0 fdo/pri-fidoiot-v1.1.5/owner $WORKDIR/pri-fidoiot-v1.1.5/owner/
 
 # Get script files. The owner subdir will be created automatically by COPY
 # Note: need to use uid and gid to be able to build on non-linux hosts
-COPY --chown=1000:0 fdo/pri-fidoiot-v1.1.4/scripts $WORKDIR/pri-fidoiot-v1.1.4/scripts/
+COPY --chown=1000:0 fdo/pri-fidoiot-v1.1.5/scripts $WORKDIR/pri-fidoiot-v1.1.5/scripts/
 
 
 # Get OCS files

--- a/docker/start-fdo-owner-service.sh
+++ b/docker/start-fdo-owner-service.sh
@@ -10,7 +10,7 @@ ocsDbDir="${1:-"ocs-db/"}"
 ocsApiPort="${2:-${SDO_OCS_API_TLS_PORT:-${SDO_OCS_API_PORT:-$ocsApiPortDefault}}}"  # precedence: arg, or tls port, or non-tls port, or default
 
 workingDir='/home/fdouser'
-deviceBinaryDir='pri-fidoiot-v1.1.4'
+deviceBinaryDir='pri-fidoiot-v1.1.5'
 # These can be passed in via CLI args or env vars
 tmp_pass=`head -c 10 /dev/random | base64`
 random_pass="apiUser:"$tmp_pass
@@ -23,7 +23,7 @@ FDO_DB_PASSWORD=${FDO_DB_PASSWORD:-"fdouser"}
 HZN_FDO_API_URL=${HZN_FDO_API_URL:-"http://$(hostname):$ownerApiPort"}
 FDO_DB_URL=${FDO_DB_URL:-"jdbc:postgresql://$(hostname):5432/fdo"}
 #VERBOSE='true'   # let it be set by the container provisioner
-FDO_SUPPORT_RELEASE=${FDO_SUPPORT_RELEASE:-https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.4}
+FDO_SUPPORT_RELEASE=${FDO_SUPPORT_RELEASE:-https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5}
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     cat << EndOfMessage

--- a/docker/start-fdo-owner-service.sh
+++ b/docker/start-fdo-owner-service.sh
@@ -18,12 +18,14 @@ FDO_API_PWD="${FDO_API_PWD:-$random_pass}"
 ownerApiPort="${1:-$ownerPortDefault}"  # precedence: arg, or tls port, or non-tls port, or default
 ownerPort=${HZN_FDO_SVC_URL:-$ownerPortDefault}
 ownerExternalPort=${FDO_OWNER_EXTERNAL_PORT:-$ownerPort}
-FDO_DB_USER=${FDO_DB_USER:-"fdouser"}
-FDO_DB_PASSWORD=${FDO_DB_PASSWORD:-"fdouser"}
-HZN_FDO_API_URL=${HZN_FDO_API_URL:-"http://$(hostname):$ownerApiPort"}
-FDO_DB_URL=${FDO_DB_URL:-"jdbc:postgresql://$(hostname):5432/fdo"}
+FDO_DB_USER=${FDO_DB_USER:-}
+FDO_DB_PASSWORD=${FDO_DB_PASSWORD:-}
+#$(hostname)
+HZN_FDO_API_URL=${HZN_FDO_API_URL:-"http://127.0.0.1:$ownerApiPort"}
+#$(hostname)
+FDO_DB_URL=${FDO_DB_URL:-"jdbc:postgresql://postgres-fdo-owners-service:5432/fdo"}
 #VERBOSE='true'   # let it be set by the container provisioner
-FDO_SUPPORT_RELEASE=${FDO_SUPPORT_RELEASE:-https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5}
+FDO_SUPPORT_RELEASE=${FDO_SUPPORT_RELEASE:-https://github.com/fido-device-onboard/release-fidoiot/releases/download/v1.1.5}
 
 if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     cat << EndOfMessage

--- a/docs/FDO-APIs.md
+++ b/docs/FDO-APIs.md
@@ -1,7 +1,7 @@
 ---
 copyright:
 years: 2022 - 2023
-lastupdated: "2023-02-19"
+lastupdated: "2023-05-24"
 title: "FDO API guide"
 description: "FDO API detailed documentation"
 

--- a/docs/README-FDO1.1.md
+++ b/docs/README-FDO1.1.md
@@ -19,7 +19,6 @@ has_children: true
 - **Ubuntu 20.04**
 - **Maven 3.6.3**
 - **Java 11**
-- **Haveged**
 
 ## Source Layout
 

--- a/docs/README-FDO1.1.md
+++ b/docs/README-FDO1.1.md
@@ -1,7 +1,7 @@
 ---
 copyright:
 years: 2022 - 2023
-lastupdated: "2023-02-19"
+lastupdated: "2023-05-25"
 title: "FDO Protocol Reference"
 description: "FDO Protocol Reference Implementation Quick Start"
 

--- a/docs/ocs-api-swagger.json
+++ b/docs/ocs-api-swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (FIDO Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an Open Horizon Management Hub instance. Open Horizon has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the Open Horizon Management Hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
-    "version": "1.1.0",
+    "version": "1.2.0",
     "title": "Open Horizon Support for FDO",
     "license": {
       "name": "Apache 2.0",

--- a/docs/ocs-api-swagger.json
+++ b/docs/ocs-api-swagger.json
@@ -1,8 +1,8 @@
 {
   "swagger": "2.0",
   "info": {
-    "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (Secure Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an IEAM instance. IEAM has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the IEAM management hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
-    "version": "1.0.0",
+    "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (FIDO Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an Open Horizon Management Hub instance. Open Horizon has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the Open Horizon Management Hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
+    "version": "1.1.0",
     "title": "Open Horizon Support for FDO",
     "license": {
       "name": "Apache 2.0",
@@ -227,6 +227,13 @@
             "name": "org-id",
             "in": "path",
             "description": "org ID of the keys you want",
+            "required": true,
+            "type": "string"
+          },
+          {
+            "name": "alias",
+            "in": "path",
+            "description": "",
             "required": true,
             "type": "string"
           }

--- a/docs/ocs-api-swagger.json
+++ b/docs/ocs-api-swagger.json
@@ -2,7 +2,7 @@
   "swagger": "2.0",
   "info": {
     "description": "[Intel FDO](https://software.intel.com/en-us/secure-device-onboard) (FIDO Device Onboard) is a technology that is created by Intel to make it easy and secure to configure edge devices and associate them with an Open Horizon Management Hub instance. Open Horizon has added support for FDO-enabled devices so that the agent will be installed on the device and registered to the Open Horizon Management Hub with zero touch (by simply powering on the device).<br><br>Examples of using this API:<br><br>`curl -sS $HZN_FDO_SVC_URL/version && echo`<br>`curl -sS -w %{http_code} -u $HZN_ORG_ID/$HZN_EXCHANGE_USER_AUTH $HZN_FDO_SVC_URL/orgs/$HZN_ORG_ID/fdo/vouchers | jq`<br><br>Note: Some of these APIs can also be run via the `hzn` command.",
-    "version": "1.2.0",
+    "version": "1.1.0",
     "title": "Open Horizon Support for FDO",
     "license": {
       "name": "Apache 2.0",

--- a/getFDO.sh
+++ b/getFDO.sh
@@ -19,26 +19,26 @@ mkdir -p ${SCRIPT_LOCATION}/fdo && cd ${SCRIPT_LOCATION}/fdo
 chk $? 'making fdo dir'
 
 echo "Getting client-sdk-fidoiot"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/client-sdk-fidoiot-v1.1.5.tar.gz
+curl --progress-bar -LO https://github.com/fido-device-onboard/release-fidoiot/releases/download/v1.1.5/client-sdk-fidoiot-v1.1.5.tar.gz
 chk $? 'downloading client-sdk-fidoiot'
 tar -zxf client-sdk-fidoiot-v1.1.5.tar.gz
 chk $? 'unpacking client-sdk-fidoiot'
 
 
 echo "Getting Protocol Reference Implementation"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/pri-fidoiot-v1.1.5.tar.gz
+curl --progress-bar -LO https://github.com/fido-device-onboard/release-fidoiot/releases/download/v1.1.5/pri-fidoiot-v1.1.5.tar.gz
 chk $? 'downloading pri'
 tar -zxf pri-fidoiot-v1.1.5.tar.gz
 chk $? 'unpacking pri'
 
 echo "Getting NOTICES"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/NOTICES-v1.1.5.tar.gz
+curl --progress-bar -LO https://github.com/fido-device-onboard/release-fidoiot/releases/download/v1.1.5/NOTICES-v1.1.5.tar.gz
 chk $? 'downloading NOTICES'
 tar -zxf NOTICES-v1.1.5.tar.gz
 chk $? 'unpacking NOTICES'
 
 echo "Getting Third Party Components"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/third-party-components.tar.gz
+curl --progress-bar -LO https://github.com/fido-device-onboard/release-fidoiot/releases/download/v1.1.5/third-party-components.tar.gz
 chk $? 'downloading third-party-components'
 tar -zxf third-party-components.tar.gz
 chk $? 'unpacking third-party-components'

--- a/getFDO.sh
+++ b/getFDO.sh
@@ -14,31 +14,31 @@ chk() {
     exit $exitCode
 }
 
-echo "Retrieving Intel FDO Release 1.1.4 dependencies..."
+echo "Retrieving Intel FDO Release 1.1.5 dependencies..."
 mkdir -p ${SCRIPT_LOCATION}/fdo && cd ${SCRIPT_LOCATION}/fdo
 chk $? 'making fdo dir'
 
 echo "Getting client-sdk-fidoiot"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.4/client-sdk-fidoiot-v1.1.4.tar.gz
+curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/client-sdk-fidoiot-v1.1.5.tar.gz
 chk $? 'downloading client-sdk-fidoiot'
-tar -zxf client-sdk-fidoiot-v1.1.4.tar.gz
+tar -zxf client-sdk-fidoiot-v1.1.5.tar.gz
 chk $? 'unpacking client-sdk-fidoiot'
 
 
 echo "Getting Protocol Reference Implementation"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.4/pri-fidoiot-v1.1.4.tar.gz
+curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/pri-fidoiot-v1.1.5.tar.gz
 chk $? 'downloading pri'
-tar -zxf pri-fidoiot-v1.1.4.tar.gz
+tar -zxf pri-fidoiot-v1.1.5.tar.gz
 chk $? 'unpacking pri'
 
 echo "Getting NOTICES"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.4/NOTICES-v1.1.4.tar.gz
+curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/NOTICES-v1.1.5.tar.gz
 chk $? 'downloading NOTICES'
-tar -zxf NOTICES-v1.1.4.tar.gz
+tar -zxf NOTICES-v1.1.5.tar.gz
 chk $? 'unpacking NOTICES'
 
 echo "Getting Third Party Components"
-curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.4/third-party-components.tar.gz
+curl --progress-bar -LO https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.5/third-party-components.tar.gz
 chk $? 'downloading third-party-components'
 tar -zxf third-party-components.tar.gz
 chk $? 'unpacking third-party-components'

--- a/sample-mfg/fdo_to.service
+++ b/sample-mfg/fdo_to.service
@@ -10,8 +10,8 @@ Before=user-sessions.service
 [Service]
 # For oneshot, systemd expects the command to NOT fork itself, and timeout is disabled by default
 Type=oneshot
-WorkingDirectory=/home/device/fdo/pri-fidoiot-v1.1.1/device
-ExecStart=/bin/java -jar /home/device/fdo/pri-fidoiot-v1.1.1/device/device.jar
+WorkingDirectory=/home/device/fdo/pri-fidoiot-v1.1.5/device
+ExecStart=/bin/java -jar /home/device/fdo/pri-fidoiot-v1.1.5/device/device.jar
 
 [Install]
 WantedBy=multi-user.target

--- a/sample-mfg/start-mfg.sh
+++ b/sample-mfg/start-mfg.sh
@@ -195,11 +195,11 @@ else
     fi
 
 
-if ! command haveged --help >/dev/null 2>&1; then
-    echo "Haveged is required, installing it"
-    sudo apt-get install -y haveged
-    chk $? 'installing haveged'
-fi
+#if ! command haveged --help >/dev/null 2>&1; then
+#    echo "Haveged is required, installing it"
+#    sudo apt-get install -y haveged
+#    chk $? 'installing haveged'
+#fi
 
 # If docker isn't installed, do that
 if ! command -v docker >/dev/null 2>&1; then

--- a/sample-mfg/start-mfg.sh
+++ b/sample-mfg/start-mfg.sh
@@ -35,13 +35,18 @@ if [[ "$1" == "-h" || "$1" == "--help" ]]; then
     usage 0
 fi
 
+export HZN_EXCHANGE_USER_AUTH=${HZN_EXCHANGE_USER_AUTH:-}
+export FDO_RV_URL=${FDO_RV_URL:-}
+export HZN_FDO_SVC_URL={HZN_FDO_SVC_URL:-http://127.0.0.1:9008}
+export HZN_ORG_ID=${HZN_ORG_ID:-}
+
 if [[ -z "$HZN_EXCHANGE_USER_AUTH" || -z "$FDO_RV_URL" || -z "$HZN_FDO_SVC_URL" || -z "$HZN_ORG_ID" ]]; then
     echo "Error: These environment variable must be set to access Owner services APIs: HZN_EXCHANGE_USER_AUTH, FDO_RV_URL, HZN_FDO_SVC_URL, HZN_ORG_ID"
     exit 0
 fi
 
 
-deviceBinaryDir='pri-fidoiot-v1.1.1'   # the place we will unpack sdo_device_binaries_1.10_linux_x64.tar.gz to
+deviceBinaryDir='pri-fidoiot-v1.1.5'   # the place we will unpack sdo_device_binaries_1.10_linux_x64.tar.gz to
 rvHttpPort=${1:-80}
 rvHttpsPort=${2:-443} #Will change to 8041 when https is enabled
 rvUrl="$FDO_RV_URL"   # the external rv url that the device should reach it at
@@ -56,7 +61,7 @@ if [[ -f "$ownerPubKeyFile" ]]; then
 fi
 
 # These environment variables can be overridden
-FDO_SUPPORT_RELEASE=${FDO_SUPPORT_RELEASE:-https://github.com/secure-device-onboard/release-fidoiot/releases/download/v1.1.1}
+FDO_SUPPORT_RELEASE=${FDO_SUPPORT_RELEASE:-https://github.com/fido-device-onboard/release-fidoiot/releases/download/v1.1.1}
 useNativeClient=${FDO_DEVICE_USE_NATIVE_CLIENT:-false}   # possible values: false (java client), host (TO native on host), docker (TO native in container)
 
 workingDir=fdo
@@ -215,7 +220,7 @@ fi
 
 # If docker-compose isn't installed, or isn't at least 1.21.0 (when docker-compose.yml version 2.4 was introduced), then install/upgrade it
 # For the dependency on 1.21.0 or greater, see: https://docs.docker.com/compose/release-notes/
-minVersion=1.21.0
+minVersion=1.29.2
 if ! isDockerComposeAtLeast $minVersion; then
     if [[ -f '/usr/bin/docker-compose' ]]; then
         echo "Error: Need at least docker-compose $minVersion. A down-level version is currently installed, preventing us from installing the latest version. Uninstall docker-compose and rerun this script."

--- a/sample-mfg/start-mfg.sh
+++ b/sample-mfg/start-mfg.sh
@@ -187,7 +187,7 @@ echo "creating and switching to $workingDir"
 #fi
 # else they explicitly set it
 
-# Make sure the host has the necessary software: java 11, docker-ce, docker-compose >= 1.21.0
+# Make sure the host has the necessary software: java 11, docker-ce, docker-compose >= 1.29.2
 confirmcmds grep curl ping   # these should be in the minimal ubuntu
 
     # If java 11 isn't installed, do that
@@ -218,8 +218,8 @@ if ! command -v docker >/dev/null 2>&1; then
 fi
 
 
-# If docker-compose isn't installed, or isn't at least 1.21.0 (when docker-compose.yml version 2.4 was introduced), then install/upgrade it
-# For the dependency on 1.21.0 or greater, see: https://docs.docker.com/compose/release-notes/
+# If docker-compose isn't installed, or isn't at least 1.29.2 (when docker-compose.yml version 2.4 was introduced), then install/upgrade it
+# For the dependency on 1.29.2 or greater, see: https://docs.docker.com/compose/release-notes/
 minVersion=1.29.2
 if ! isDockerComposeAtLeast $minVersion; then
     if [[ -f '/usr/bin/docker-compose' ]]; then

--- a/tools/grabCreds.sh
+++ b/tools/grabCreds.sh
@@ -7,7 +7,7 @@ grabCreds() {
     for i in ${components[@]}; do
         if [[ "${components[@]}" =~ "$i" ]]; then
 
-            keypwd="$(grep -E '^ *api_password=' fdo/pri-fidoiot-v1.1.0.2/$i/service.env)"
+            keypwd="$(grep -E '^ *api_password=' fdo/pri-fidoiot-v1.1.5/$i/service.env)"
             API_PWD=${keypwd#api_password=}
            
 	    echo export "$i"=$API_PWD

--- a/tools/grabCreds.sh
+++ b/tools/grabCreds.sh
@@ -7,7 +7,7 @@ grabCreds() {
     for i in ${components[@]}; do
         if [[ "${components[@]}" =~ "$i" ]]; then
 
-            keypwd="$(grep -E '^ *api_password=' fdo/pri-fidoiot-v1.1.5/$i/service.env)"
+            keypwd="$(grep -E '^ *api_password=' fdo/pri-fidoiot-v1.1.0.2/$i/service.env)"
             API_PWD=${keypwd#api_password=}
            
 	    echo export "$i"=$API_PWD


### PR DESCRIPTION
References: #25

Changes:
- Issue 25: Updated FDO to support Intel's 1.1.5 release.
- Updated FDO fetch address to reference FDO's new development organization domain.
- Updated Docker container's base image to Red Hat UBI 9 minimal.