### PR TITLE
Adding Nathan Phelps to MAINTAINERS.md

### DIFF
--- a/MAINTAINERS.md
+++ b/MAINTAINERS.md
@@ -3,7 +3,8 @@ Repository Maintainers
 
 See the information about [community membership roles](https://wiki.lfedge.org/display/OH/Community+Membership) to learn about the role of the maintainers and the process to become one.
 
-| Name         | GitHub                                         | Email                     |
-|--------------|------------------------------------------------|---------------------------|
-| Bruce Potter | [@bmpotter](https://github.com/bmpotter)       | <bp@us.ibm.com>           |
-| Lorenzo King | [@lorenzoking](https://github.com/lorenzoking) | <Lorenzomkingiii@ibm.com> |
+| Name           | GitHub                                         | Email                     |
+|----------------|------------------------------------------------|---------------------------|
+| Bruce Potter   | [@bmpotter](https://github.com/bmpotter)       | <bp@us.ibm.com>           |
+| Lorenzo King   | [@lorenzoking](https://github.com/lorenzoking) | <Lorenzomkingiii@ibm.com> |
+| Nathan Phelps  | [@naphelps](https://github.com/naphelps)       | <naphelps@us.ibm.com>     |


### PR DESCRIPTION
References:

Changes:
- Promoting Nathan Phelps to a maintainer of FDO-support.