### PR TITLE
Issue-46: Removed 'Intel' from phrase 'Intel FDO'

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,7 +10,7 @@ All notable changes to this project will be documented in this file.
 - Makefile will now download needed FDO release resources from GitHub.
 
 ## [1.1.0] - 2023-05-24
-- Issue 25: Updated FDO to support Intel's `1.1.5` release.
+- Issue 25: Updated FDO to support FDO Project's `1.1.5` release.
 - Updated FDO fetch address to reference FDO's new development organization domain.
 - Updated Docker container's base image to Red Hat UBI 9 minimal.
 

--- a/README.md
+++ b/README.md
@@ -55,7 +55,7 @@ The FDO owner service are packaged as a single docker container that can be run 
 
 Before continuing with the rest of the FDO process, it is good to verify that you have the correct information necessary to reach the FDO owner service endpoints. **On a Horizon "admin" host** run these simple FDO APIs to verify that the services are accessible and responding properly. (A Horizon admin host is one that has the `horizon-cli` package installed, which provides the `hzn` command, and has the environment variables `HZN_EXCHANGE_URL`, `HZN_FDO_SVC_URL`, and `HZN_EXCHANGE_USER_AUTH` set correctly for your Horizon management hub.)
 
-Intel FIDO Device Onboard Rendezvous Servers:
+FIDO Device Onboard Rendezvous Servers:
 ```bash
  Development:
    http://test.fdorv.com:80
@@ -357,7 +357,7 @@ These steps only need to be performed by developers of this project
 
 ### <a name="new-fdo-version"></a>Checklist For Moving Up to a New FDO Version
 
-What to modify in our FDO support code when Intel releases a new version of FDO:
+What to modify in our FDO support code when the FDO project releases a new version of FDO:
 
 - Update `.gitignore` and `.dockerignore`
   - `mv fdo fdo-<prev-version>`

--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,10 +1,10 @@
 FROM registry.access.redhat.com/ubi9-minimal:latest
 
 # Builds a composite docker service that the "owner" needs to run. Specifically it contains the following services:
-#   Intel FDO development/test rendezvous service
-#   Intel FDO to0scheduler service
-#   Intel FDO OPS (Owner Protocol Service)
-#   Intel FDO OCS (Owner Companion Service)
+#   FDO development/test rendezvous service
+#   FDO to0scheduler service
+#   FDO OPS (Owner Protocol Service)
+#   FDO OCS (Owner Companion Service)
 #   Open-horizon ocs-api (OCS REST API)
 
 # Building a UBI image:

--- a/docs/ocs-api-swagger.yml
+++ b/docs/ocs-api-swagger.yml
@@ -1,8 +1,8 @@
 openapi: 3.0.1
 info:
   title: Open Horizon Support for FDO
-  description: '[Intel FDO](https://software.intel.com/en-us/secure-device-onboard)
-    (FIDO Device Onboard) is a technology that is created by Intel to make it easy
+  description: '[FDO](https://software.intel.com/en-us/secure-device-onboard)
+    (FIDO Device Onboard) is a technology that is contributed by Intel to make it easy
     and secure to configure edge devices and associate them with an Open Horizon Management
     Hub instance. Open Horizon has added support for FDO-enabled devices so that the
     agent will be installed on the device and registered to the Open Horizon Management

--- a/getFDO.sh
+++ b/getFDO.sh
@@ -14,7 +14,7 @@ chk() {
     exit $exitCode
 }
 
-echo "Retrieving Intel FDO Release 1.1.5 dependencies..."
+echo "Retrieving FDO Release 1.1.5 dependencies..."
 mkdir -p ${SCRIPT_LOCATION}/fdo && cd ${SCRIPT_LOCATION}/fdo
 chk $? 'making fdo dir'
 

--- a/sample-mfg/start-mfg.sh
+++ b/sample-mfg/start-mfg.sh
@@ -6,7 +6,7 @@
 #   - extend the Ownership Voucher to the owner (buyer)
 #   - Switch the device into owner mode
 
-# This script starts/uses the Manufacturer services. See the Intel FDO Manufacturer Enablement Guide
+# This script starts/uses the Manufacturer services. See the FDO Manufacturer Enablement Guide
 # These Manufacturer services are not for production use.
 
 # Supports Fedora 36+ and Ubuntu 2x.04


### PR DESCRIPTION
Per request from Intel and the FDO project, find all instances of the phrase `Intel FDO` and replace with just `FDO` or `The FDO Project` as appropriate.  Notify FDO's TSC when this is merged.