### PR TITLE
Issue-53: fixed broken link, added external link hints

### DIFF
--- a/docs/README-FDO.md
+++ b/docs/README-FDO.md
@@ -1,7 +1,7 @@
 ---
 copyright:
-years: 2022 - 2023
-lastupdated: "2023-06-06"
+years: 2022 - 2024
+lastupdated: "2024-03-01"
 title: "FDO Protocol Reference"
 description: "FDO Protocol Reference Implementation Quick Start"
 
@@ -12,7 +12,7 @@ has_children: true
 
 # FIDO Device Onboard (FDO) Protocol Reference Implementation (PRI) Quick Start
 
-***NOTE***: This is a preliminary implementation of the [FIDO Device Onboard Spec](https://fidoalliance.org/specs/FDO/fido-device-onboard-v1.0-ps-20210323/) published by the FIDO Alliance. The implementation is experimental and incomplete, and is not ready for use in any production capacity. Some cryptographic algorithms and encoding formats have not been implemented, and any aspect of this implementation is subject to change.
+***NOTE***: This is a preliminary implementation of the [FIDO Device Onboard Spec](https://fidoalliance.org/specs/FDO/fido-device-onboard-v1.0-ps-20210323/){:target="_blank"}{: .externalLink} published by the FIDO Alliance. The implementation is experimental and incomplete, and is not ready for use in any production capacity. Some cryptographic algorithms and encoding formats have not been implemented, and any aspect of this implementation is subject to change.
 
 ## System Requirements
 
@@ -34,8 +34,8 @@ FDO PRI source code is organized into the following sub-folders.
 
 ## Building FDO PRI Source
 
-FDO PRI source is written in [Java 11](https://openjdk.java.net/projects/jdk/11/) and uses the
-[Apache Maven* software](http://maven.apache.org).
+FDO PRI source is written in [Java 11](https://openjdk.java.net/projects/jdk/11/){:target="_blank"}{: .externalLink} and uses the
+[Apache Maven* software](http://maven.apache.org){:target="_blank"}{: .externalLink}.
 
 Following ports are used for unit-tests and sample code - 8039, 8040, 8042, 8043, 8049, 8050, and 8051.
 Ensure that these ports are not used by other applications while building and executing the
@@ -228,10 +228,10 @@ EPID devices can be tested using `Test` mode. EPID `Test` mode feature is intend
 
 ## Using Component Samples
 
-Refer to [Demo README](component-samples/demo/README.md) for steps to run component sample demo.
+Refer to [Demo README](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/component-samples/demo/README.MD){:target="_blank"}{: .externalLink} for steps to run component sample demo.
 
 ## Support for OnDie Devices
 
-Refer to [Demo README](component-samples/demo/README.md) for steps to configure component-samples to support OnDie devices.
+Refer to [Demo README](https://github.com/fido-device-onboard/pri-fidoiot/blob/master/component-samples/demo/README.MD){:target="_blank"}{: .externalLink} for steps to configure component-samples to support OnDie devices.
 
 Support for OnDie devices is built into the protocol-samples and no configuration is required. The OnDie certs and CRLs are preloaded into the protocol-samples/onDieCache directory. Should these need to be refreshed (in case of devices released after the FDO PRI release) then the script in component-samples/onDieScript.py can be used to update the artifacts in this directory.


### PR DESCRIPTION
Re-pointed demo links at bottom of the page from a local path which did not exist, to the correct external location pointed out by @naphelps 