### PR TITLE
Fix CWE-22 Path/Directory Traversal issues

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.6.0] - 2025-06.04
+-  Fix CWE-22 Path/Directory Traversal issues
+
 ## [1.5.0] - 2025-05.06
 - Add a script to support the FDO RV server.
 - Update README.md

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and FDO-owner-services (for now they use the samme version number)
-export VERSION ?= 1.5.0
+export VERSION ?= 1.6.0
 export FIDO_DEVICE_ONBOARD_REL_VER ?= 1.1.9
 # used by sample-mfg/Makefile. Needs to match what is in fdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
-STABLE_VERSION ?= 1.5.0
+STABLE_VERSION ?= 1.6.0
 
 #todo: add BUILD_NUMBER like in anax/Makefile
 

--- a/ocs-api/main.go
+++ b/ocs-api/main.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"encoding/base64"
 	"fmt"
-	"io/ioutil"
+	"io"
 	"log"
 	"net/http"
 	"os"
@@ -82,8 +82,8 @@ func main() {
 	http.HandleFunc("/api/", apiHandler)
 
 	// Set To2 Address on start up in FDO Owner Services
-    fdoTo2Host, fdoTo2Port := outils.GetTo2OwnerHost()
-    fmt.Println("Setting To2 Address as: " + fdoTo2Host + ":" + fdoTo2Port)
+	fdoTo2Host, fdoTo2Port := outils.GetTo2OwnerHost()
+	fmt.Println("Setting To2 Address as: " + fdoTo2Host + ":" + fdoTo2Port)
 	fdoOwnerURL := os.Getenv("HZN_FDO_API_URL")
 	if fdoOwnerURL == "" {
 		log.Fatalln("HZN_FDO_API_URL is not set")
@@ -111,7 +111,7 @@ func main() {
 	valuesDir := OcsDbDir + "/v1/values"
 	fileName := valuesDir + "/agent-install.crt"
 	fmt.Println("Posting agent-install.crt package: " + fileName)
-	certFile, err := ioutil.ReadFile(fileName)
+	certFile, err := os.ReadFile(fileName)
 	if err != nil {
 		outils.NewHttpError(http.StatusInternalServerError, "Error reading "+fileName+": "+err.Error())
 		return
@@ -134,7 +134,7 @@ func main() {
 	valuesDir = OcsDbDir + "/v1/values"
 	fileName = valuesDir + "/agent-install.cfg"
 	fmt.Println("Posting agent-install.cfg package: " + fileName)
-	cfgFile, err := ioutil.ReadFile(fileName)
+	cfgFile, err := os.ReadFile(fileName)
 	if err != nil {
 		outils.NewHttpError(http.StatusInternalServerError, "Error reading "+fileName+": "+err.Error())
 		return
@@ -156,7 +156,7 @@ func main() {
 	valuesDir = OcsDbDir + "/v1/values"
 	fileName = valuesDir + "/agent-install-wrapper.sh"
 	fmt.Println("Setting SVI package: " + fileName)
-	wrapperFile, err := ioutil.ReadFile(fileName)
+	wrapperFile, err := os.ReadFile(fileName)
 	if err != nil {
 		outils.NewHttpError(http.StatusInternalServerError, "Error reading "+fileName+": "+err.Error())
 		return
@@ -185,7 +185,7 @@ func main() {
 		}
 		ExchangeInternalCertPath = workingDir + "/agent-install.crt"
 		outils.Verbose("Creating %s ...", ExchangeInternalCertPath)
-		if err := ioutil.WriteFile(ExchangeInternalCertPath, crtBytes, 0644); err != nil {
+		if err := os.WriteFile(ExchangeInternalCertPath, crtBytes, 0644); err != nil {
 			outils.Fatal(3, "could not create "+ExchangeInternalCertPath+": "+err.Error())
 		}
 	}
@@ -226,7 +226,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 	} else if matches := OrgFDORedirectRegex.FindStringSubmatch(r.URL.Path); r.Method == "POST" && len(matches) >= 2 { // POST /api/orgs/{ord-id}/fdo/redirect
 		postFdoRedirectHandler(matches[1], w, r)
 	} else if matches := OrgFDORedirectRegex.FindStringSubmatch(r.URL.Path); r.Method == "GET" && len(matches) >= 2 { // GET /api/orgs/{ord-id}/fdo/redirect
-    	getFdoRedirectHandler(matches[1], w, r)
+		getFdoRedirectHandler(matches[1], w, r)
 	} else if matches := GetFDOTo0Regex.FindStringSubmatch(r.URL.Path); r.Method == "GET" && len(matches) >= 3 { // GET /api/orgs/{ord-id}/fdo/to0/{deviceUuid}
 		getFdoTo0Handler(matches[1], matches[2], w, r)
 	} else if matches := OrgFDOResourceRegex.FindStringSubmatch(r.URL.Path); r.Method == "POST" && len(matches) >= 3 { // POST /api/orgs/{ord-id}/fdo/resource/{resourceFile}
@@ -244,7 +244,7 @@ func apiHandler(w http.ResponseWriter, r *http.Request) {
 
 // Route Handlers --------------------------------------------------------------------------------------------------
 
-//============= GET /api/version =============
+// ============= GET /api/version =============
 // Returns the ocs-api version (in plain text, not json)
 func getVersionHandler(w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/version ...")
@@ -258,7 +258,7 @@ func getVersionHandler(w http.ResponseWriter, r *http.Request) {
 	}
 }
 
-//============= GET /api/fdo/version =============
+// ============= GET /api/fdo/version =============
 // Returns the fdo Owner Service version (in plain text, not json)
 func getFdoVersionHandler(w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/fdo/version ...")
@@ -273,7 +273,7 @@ func getFdoVersionHandler(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusBadRequest)
 		return
 	}
-	body, err := ioutil.ReadAll(resp.Body)
+	body, err := io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -284,7 +284,7 @@ func getFdoVersionHandler(w http.ResponseWriter, r *http.Request) {
 
 }
 
-//============= GET /api/orgs/{ord-id}/fdo/certificate/<alias> =============
+// ============= GET /api/orgs/{ord-id}/fdo/certificate/<alias> =============
 // Reads/returns owner service public keys based off device alias
 func getFdoPublicKeyHandler(orgId string, publicKeyType string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/orgs/%s/fdo/certificate/%s ...", orgId)
@@ -307,7 +307,7 @@ func getFdoPublicKeyHandler(orgId string, publicKeyType string, w http.ResponseW
 		return
 	}
 
-    //Only 5 public key alias types allowed
+	//Only 5 public key alias types allowed
 	if (publicKeyType) != "SECP256R1" && (publicKeyType) != "SECP384R1" && (publicKeyType) != "RSAPKCS3072" && (publicKeyType) != "RSAPKCS2048" && (publicKeyType) != "RSA2048RESTR" {
 		http.Error(w, "Public key type must be one of these supported alias': SECP256R1, SECP384R1, RSAPKCS3072, RSAPKCS2048, RSA2048RESTR", http.StatusBadRequest)
 		return
@@ -333,7 +333,7 @@ func getFdoPublicKeyHandler(orgId string, publicKeyType string, w http.ResponseW
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -346,8 +346,8 @@ func getFdoPublicKeyHandler(orgId string, publicKeyType string, w http.ResponseW
 	outils.WriteResponse(http.StatusOK, w, respBodyBytes)
 }
 
-//IMPORT VOUCHER
-//============= POST /api/orgs/{ord-id}/fdo/vouchers and POST /api/fdo/vouchers =============
+// IMPORT VOUCHER
+// ============= POST /api/orgs/{ord-id}/fdo/vouchers and POST /api/fdo/vouchers =============
 // Imports a voucher
 func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("POST /api/orgs/%s/fdo/vouchers ... ...", orgId)
@@ -379,7 +379,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 		return
 	}
 
-	bodyBytes, err := ioutil.ReadAll(r.Body) // we need the request body so get it as bytes
+	bodyBytes, err := io.ReadAll(r.Body) // we need the request body so get it as bytes
 	if err != nil {
 		http.Error(w, "Error reading the request body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -407,7 +407,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -427,7 +427,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 	// Put the voucher in the OCS DB
 	fileName := deviceDir + "/ownership_voucher.txt"
 	outils.Verbose("POST /api/orgs/%s/fdo/vouchers: creating %s ...", deviceOrgId, fileName)
-	if err := ioutil.WriteFile(filepath.Clean(fileName), bodyBytes, 0644); err != nil {
+	if err := os.WriteFile(filepath.Clean(fileName), bodyBytes, 0644); err != nil {
 		http.Error(w, "could not create "+fileName+": "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -435,7 +435,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 	// Create orgid.txt file to identify what org this device/voucher is part of
 	fileName = deviceDir + "/orgid.txt"
 	outils.Verbose("POST /api/orgs/%s/vouchers: creating %s with value: %s ...", deviceOrgId, fileName, deviceOrgId)
-	if err := ioutil.WriteFile(filepath.Clean(fileName), []byte(deviceOrgId), 0644); err != nil {
+	if err := os.WriteFile(filepath.Clean(fileName), []byte(deviceOrgId), 0644); err != nil {
 		http.Error(w, "could not create "+fileName+": "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -452,7 +452,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 	execCmd := fmt.Sprintf("/bin/sh agent-install-wrapper.sh -i %s -a %s:%s -O %s -k %s", PkgsFrom, deviceUuid, nodeToken, deviceOrgId, CfgFileFrom)
 	fileName = OcsDbDir + "/v1/values/" + deviceUuid + "_exec"
 	outils.Verbose("POST /api/orgs/%s/vouchers: creating %s ...", deviceOrgId, fileName)
-	if err := ioutil.WriteFile(filepath.Clean(fileName), []byte(execCmd), 0644); err != nil {
+	if err := os.WriteFile(filepath.Clean(fileName), []byte(execCmd), 0644); err != nil {
 		http.Error(w, "could not create "+fileName+": "+err.Error(), http.StatusInternalServerError)
 		return
 	}
@@ -461,7 +461,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 	valuesDir := OcsDbDir + "/v1/values"
 	fileName = valuesDir + "/" + deviceUuid + "_exec"
 	fmt.Println("Device Specific Wrapper: " + fileName)
-	wrapperFile, err := ioutil.ReadFile(fileName)
+	wrapperFile, err := os.ReadFile(fileName)
 	if err != nil {
 		http.Error(w, "Error reading "+fileName+": "+err.Error(), http.StatusNotFound)
 		return
@@ -509,7 +509,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(postResponse.Body)
+	respBodyBytes, err = io.ReadAll(postResponse.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -530,7 +530,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 
 }
 
-//============= GET /api/orgs/{ord-id}/fdo/vouchers =============
+// ============= GET /api/orgs/{ord-id}/fdo/vouchers =============
 // Reads/returns all of the already imported vouchers
 func getFdoVouchersHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/orgs/%s/fdo/vouchers ...", orgId)
@@ -580,7 +580,7 @@ func getFdoVouchersHandler(orgId string, w http.ResponseWriter, r *http.Request)
 
 	// Read the v1/devices/ directory in the db for multitenancy
 	vouchersDirName := OcsDbDir + "/v1/devices"
-	deviceDirs, err := ioutil.ReadDir(filepath.Clean(vouchersDirName))
+	deviceDirs, err := os.ReadDir(filepath.Clean(vouchersDirName))
 	if err != nil {
 		http.Error(w, "Error reading "+vouchersDirName+" directory: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -616,8 +616,8 @@ func getFdoVouchersHandler(orgId string, w http.ResponseWriter, r *http.Request)
 
 }
 
-//GET A SPECIFIED VOUCHER
-//============= GET /api/orgs/{ord-id}/fdo/vouchers/{deviceUuid} =============
+// GET A SPECIFIED VOUCHER
+// ============= GET /api/orgs/{ord-id}/fdo/vouchers/{deviceUuid} =============
 // Reads/returns a specific imported voucher
 func getFdoVoucherHandler(orgId string, deviceUuid string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/orgs/%s/fdo/vouchers/%s ...", orgId)
@@ -650,7 +650,7 @@ func getFdoVoucherHandler(orgId string, deviceUuid string, w http.ResponseWriter
 	//if not, then return error
 	// Read voucher.json from the db
 	voucherFileName := OcsDbDir + "/v1/devices/" + deviceUuid + "/ownership_voucher.txt"
-	voucherBytes, err := ioutil.ReadFile(filepath.Clean(voucherFileName))
+	voucherBytes, err := os.ReadFile(filepath.Clean(voucherFileName))
 	if err != nil {
 		http.Error(w, "Error reading "+voucherFileName+": "+err.Error(), http.StatusNotFound)
 		return
@@ -671,7 +671,7 @@ func getFdoVoucherHandler(orgId string, deviceUuid string, w http.ResponseWriter
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -704,7 +704,7 @@ func getFdoVoucherHandler(orgId string, deviceUuid string, w http.ResponseWriter
 	outils.WriteResponse(http.StatusOK, w, voucherBytes)
 }
 
-//============= POST /api/orgs/{ord-id}/fdo/redirect =============
+// ============= POST /api/orgs/{ord-id}/fdo/redirect =============
 // Configure the Owner Services TO2 address
 func postFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("POST /api/orgs/%s/fdo/redirect ... ...", orgId)
@@ -736,7 +736,7 @@ func postFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request
 		return
 	}
 
-	bodyBytes, err := ioutil.ReadAll(r.Body) // we need the request body so get it as bytes
+	bodyBytes, err := io.ReadAll(r.Body) // we need the request body so get it as bytes
 	if err != nil {
 		http.Error(w, "Error reading the request body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -766,7 +766,7 @@ func postFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -780,7 +780,7 @@ func postFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request
 	outils.WriteResponse(http.StatusOK, w, respBodyBytes)
 }
 
-//============= GET /api/orgs/{ord-id}/fdo/redirect =============
+// ============= GET /api/orgs/{ord-id}/fdo/redirect =============
 // Get the Owner Services TO2 address
 func getFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/orgs/%s/fdo/redirect ... ...", orgId)
@@ -825,7 +825,7 @@ func getFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request)
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -839,7 +839,7 @@ func getFdoRedirectHandler(orgId string, w http.ResponseWriter, r *http.Request)
 	outils.WriteResponse(http.StatusOK, w, respBodyBytes)
 }
 
-//============= GET /api/orgs/{ord-id}/fdo/to0/{deviceUuid} =============
+// ============= GET /api/orgs/{ord-id}/fdo/to0/{deviceUuid} =============
 // Initiates TO0 from Owner service
 func getFdoTo0Handler(orgId string, deviceUuid string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/orgs/%s/fdo/to0/%s ...", orgId)
@@ -880,7 +880,7 @@ func getFdoTo0Handler(orgId string, deviceUuid string, w http.ResponseWriter, r 
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -893,8 +893,8 @@ func getFdoTo0Handler(orgId string, deviceUuid string, w http.ResponseWriter, r 
 	outils.WriteResponse(http.StatusOK, w, respBodyBytes)
 }
 
-//IMPORT RESOURCE FILE (agent-install-wrapper.sh) TO OWNER DB FOR SERVICE INFO PACKAGE
-//============= POST /api/orgs/{ord-id}/fdo/resource/{resourceFile} =============
+// IMPORT RESOURCE FILE (agent-install-wrapper.sh) TO OWNER DB FOR SERVICE INFO PACKAGE
+// ============= POST /api/orgs/{ord-id}/fdo/resource/{resourceFile} =============
 // Imports a resource file to the DB in order to use for service info package
 func postFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("POST /api/orgs/%s/fdo/resource/%s ... ...", orgId)
@@ -925,7 +925,7 @@ func postFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWr
 		return
 	}
 
-	bodyBytes, err := ioutil.ReadAll(r.Body) // we need the request body so get it as bytes
+	bodyBytes, err := io.ReadAll(r.Body) // we need the request body so get it as bytes
 	if err != nil {
 		http.Error(w, "Error reading the request body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -956,7 +956,7 @@ func postFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWr
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -970,7 +970,7 @@ func postFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWr
 	outils.WriteResponse(http.StatusOK, w, respBodyBytes)
 }
 
-//============= GET /api/orgs/{ord-id}/fdo/resource/{resourceFile} =============
+// ============= GET /api/orgs/{ord-id}/fdo/resource/{resourceFile} =============
 // Gets a resource file that was imported to the DB in order to use for service info package
 func getFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("GET /api/orgs/%s/fdo/resource/%s ... ...", orgId)
@@ -1002,7 +1002,7 @@ func getFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWri
 		return
 	}
 
-	bodyBytes, err := ioutil.ReadAll(r.Body) // we need the request body so get it as bytes
+	bodyBytes, err := io.ReadAll(r.Body) // we need the request body so get it as bytes
 	if err != nil {
 		http.Error(w, "Error reading the request body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -1031,7 +1031,7 @@ func getFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWri
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -1045,7 +1045,7 @@ func getFdoResourceHandler(orgId string, resourceFile string, w http.ResponseWri
 	outils.WriteResponse(http.StatusOK, w, respBodyBytes)
 }
 
-//============= POST /api/orgs/{ord-id}/fdo/svi =============
+// ============= POST /api/orgs/{ord-id}/fdo/svi =============
 // Uploads SVI instructions to SYSTEM_PACKAGE table in owner db.
 func postFdoSVIHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 	outils.Verbose("POST /api/orgs/%s/fdo/svi ... ...", orgId)
@@ -1077,7 +1077,7 @@ func postFdoSVIHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 		return
 	}
 
-	bodyBytes, err := ioutil.ReadAll(r.Body) // we need the request body so get it as bytes
+	bodyBytes, err := io.ReadAll(r.Body) // we need the request body so get it as bytes
 	if err != nil {
 		http.Error(w, "Error reading the request body: "+err.Error(), http.StatusBadRequest)
 		return
@@ -1103,7 +1103,7 @@ func postFdoSVIHandler(orgId string, w http.ResponseWriter, r *http.Request) {
 		defer resp.Body.Close()
 	}
 
-	respBodyBytes, err = ioutil.ReadAll(resp.Body)
+	respBodyBytes, err = io.ReadAll(resp.Body)
 	if err != nil {
 		http.Error(w, "Error reading the response body: "+err.Error(), http.StatusInternalServerError)
 		return
@@ -1163,7 +1163,7 @@ func getOrgidTxtStr(deviceId string) (string, *outils.HttpError) {
 	if outils.PathExists(orgidTxtFileName) {
 		var orgidTxtBytes []byte
 		var err error
-		if orgidTxtBytes, err = ioutil.ReadFile(orgidTxtFileName); err != nil {
+		if orgidTxtBytes, err = os.ReadFile(orgidTxtFileName); err != nil {
 			return "", outils.NewHttpError(http.StatusInternalServerError, "Error reading "+orgidTxtFileName+": "+err.Error())
 		} else {
 			orgidTxtStr = string(orgidTxtBytes)
@@ -1182,7 +1182,7 @@ func getNodeTokenTxtStr(deviceId string) (string, *outils.HttpError) {
 	if outils.PathExists(nodeTokenTxtFileName) {
 		var nodeTokenTxtBytes []byte
 		var err error
-		if nodeTokenTxtBytes, err = ioutil.ReadFile(nodeTokenTxtFileName); err != nil {
+		if nodeTokenTxtBytes, err = os.ReadFile(nodeTokenTxtFileName); err != nil {
 			return "", outils.NewHttpError(http.StatusInternalServerError, "Error reading "+nodeTokenTxtFileName+": "+err.Error())
 		} else {
 			nodeTokenTxtStr = string(nodeTokenTxtBytes)
@@ -1217,14 +1217,14 @@ func createConfigFiles() *outils.HttpError {
 	if len(crt) > 0 {
 		fileName = valuesDir + "/agent-install.crt"
 		outils.Verbose("Creating %s ...", fileName)
-		if err := ioutil.WriteFile(filepath.Clean(fileName), crt, 0644); err != nil {
+		if err := os.WriteFile(filepath.Clean(fileName), crt, 0644); err != nil {
 			return outils.NewHttpError(http.StatusInternalServerError, "could not create "+fileName+": "+err.Error())
 		}
 
 		fileName = valuesDir + "/agent-install-crt_name"
 		outils.Verbose("Creating %s ...", fileName)
 		dataStr = "agent-install.crt"
-		if err := ioutil.WriteFile(filepath.Clean(fileName), []byte(dataStr), 0644); err != nil {
+		if err := os.WriteFile(filepath.Clean(fileName), []byte(dataStr), 0644); err != nil {
 			return outils.NewHttpError(http.StatusInternalServerError, "could not create "+fileName+": "+err.Error())
 		}
 	}
@@ -1245,7 +1245,7 @@ func createConfigFiles() *outils.HttpError {
 		// only add this if we actually created the agent-install.crt file above
 		dataStr += "HZN_MGMT_HUB_CERT_PATH=agent-install.crt\n"
 	}
-	if err := ioutil.WriteFile(fileName, []byte(dataStr), 0644); err != nil {
+	if err := os.WriteFile(fileName, []byte(dataStr), 0644); err != nil {
 		return outils.NewHttpError(http.StatusInternalServerError, "could not create "+fileName+": "+err.Error())
 	}
 	fmt.Printf("Will be configuring devices to use config:\n%s\n", dataStr)
@@ -1253,7 +1253,7 @@ func createConfigFiles() *outils.HttpError {
 	fileName = valuesDir + "/agent-install-cfg_name"
 	outils.Verbose("Creating %s ...", fileName)
 	dataStr = "agent-install.cfg"
-	if err := ioutil.WriteFile(filepath.Clean(fileName), []byte(dataStr), 0644); err != nil {
+	if err := os.WriteFile(filepath.Clean(fileName), []byte(dataStr), 0644); err != nil {
 		return outils.NewHttpError(http.StatusInternalServerError, "could not create "+fileName+": "+err.Error())
 	}
 
@@ -1267,7 +1267,7 @@ func createConfigFiles() *outils.HttpError {
 	fileName = valuesDir + "/agent-install-wrapper-sh_name"
 	outils.Verbose("Creating %s ...", fileName)
 	dataStr = "agent-install-wrapper.sh"
-	if err := ioutil.WriteFile(filepath.Clean(fileName), []byte(dataStr), 0644); err != nil {
+	if err := os.WriteFile(filepath.Clean(fileName), []byte(dataStr), 0644); err != nil {
 		return outils.NewHttpError(http.StatusInternalServerError, "could not create "+fileName+": "+err.Error())
 	}
 


### PR DESCRIPTION
Path/Directory Traversal or file disclosure vulnerability occurs when an external input is used to construct a pathname that is intended to identify a file or a directory located underneath a restricted parent directory. The application does not properly neutralize (sanitize) special elements within the pathname, which can cause the pathname to resolve to a location that is outside of the restricted directory. Successful file disclosure attack can result in sensitive files disclosure, and can often lead to full system compromise