### PR TITLE
Fix Server Side Request Forgery

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,9 @@
 # Changelog
 
 All notable changes to this project will be documented in this file.
+## [1.8.0] - 2025-06.18
+-  Fix CWE-918: Server Side Request Forgery
+
 ## [1.7.0] - 2025-06.04
 -  Fix CWE-73: File Manipulation
 

--- a/Makefile
+++ b/Makefile
@@ -1,9 +1,9 @@
 SHELL ?= /bin/bash -e
 # Set this before building the ocs-api binary and FDO-owner-services (for now they use the samme version number)
-export VERSION ?= 1.7.0
+export VERSION ?= 1.8.0
 export FIDO_DEVICE_ONBOARD_REL_VER ?= 1.1.9
 # used by sample-mfg/Makefile. Needs to match what is in fdo/supply-chain-tools-v<version>/docker_manufacturer/docker-compose.yml
-STABLE_VERSION ?= 1.7.0
+STABLE_VERSION ?= 1.8.0
 
 #todo: add BUILD_NUMBER like in anax/Makefile
 

--- a/ocs-api/main.go
+++ b/ocs-api/main.go
@@ -418,7 +418,7 @@ func postFdoVoucherHandler(orgId string, w http.ResponseWriter, r *http.Request)
 	outils.Verbose("POST /api/orgs/%s/fdo/vouchers: device UUID: %s", deviceOrgId, deviceUuid)
 
 	// Create the device directory in the OCS DB
-	deviceDir := filepath.Join(OcsDbDir, "v1", "devices", deviceUuid)
+	deviceDir := filepath.Clean(filepath.Join(OcsDbDir, "v1", "devices", deviceUuid))
 	if err := os.MkdirAll(deviceDir, 0750); err != nil {
 		http.Error(w, "could not create directory "+deviceDir+": "+err.Error(), http.StatusInternalServerError)
 		return


### PR DESCRIPTION
### CWE-918: Server Side Request Forgery
Server Side Request Forgery occures when the web server receives a URL or similar request from an upstream component and retrieves the contents of this URL, but it does not sufficiently ensure that the request is being sent to the expected destination. By providing URLs to unexpected hosts or ports, attackers can make it appear that the server is sending the request, possibly bypassing access controls such as firewalls that prevent the attackers from accessing the URLs directly. The server can be used as a proxy to conduct port scanning of hosts in internal networks, use other URLs such as that can access documents on the system (using file://), or use other protocols such as gopher:// or tftp://, which may provide greater control over the contents of requests

test result
<img width="1277" alt="Zrzut ekranu 2025-06-10 o 14 01 43" src="https://github.com/user-attachments/assets/bc0c333a-e98c-4141-b985-77ca57ffd3d9" />
