### PR TITLE
Update go version in ocs-api

### DIFF
--- a/ocs-api/go.mod
+++ b/ocs-api/go.mod
@@ -1,5 +1,5 @@
 module github.com/open-horizon/FDO-support/ocs-api
 
-go 1.21
+go 1.21.9
 
 require github.com/Snawoot/go-http-digest-auth-client v1.1.3

--- a/ocs-api/go.mod
+++ b/ocs-api/go.mod
@@ -1,5 +1,5 @@
 module github.com/open-horizon/FDO-support/ocs-api
 
-go 1.21.9
+go 1.23.10
 
 require github.com/Snawoot/go-http-digest-auth-client v1.1.3


### PR DESCRIPTION
### CVE-2023-45288
An attacker may cause an HTTP/2 endpoint to read arbitrary amounts of header data by sending an excessive number of CONTINUATION frames. Maintaining HPACK state requires parsing and processing all HEADERS and CONTINUATION frames on a connection. When a request\'s headers exceed MaxHeaderBytes, no memory is allocated to store the excess headers, but they are still parsed. This permits an attacker to cause an HTTP/2 endpoint to read arbitrary amounts of header data, all associated with a request which is going to be rejected. These headers can include Huffman-encoded data which is significantly more expensive for the receiver to decode than for an attacker to send. The fix sets a limit on the amount of excess header frames we will process before closing a connection.